### PR TITLE
Added response body to Conductor API errors

### DIFF
--- a/sdk/client/api_client.go
+++ b/sdk/client/api_client.go
@@ -17,8 +17,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
-	"github.com/conductor-sdk/conductor-go/sdk/settings"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -32,6 +30,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
+	"github.com/conductor-sdk/conductor-go/sdk/settings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -283,7 +284,7 @@ func (c *APIClient) getToken() (model.Token, *http.Response, error) {
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
-			error: localVarHttpResponse.Status,
+			error: string(localVarBody),
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.Task

--- a/sdk/client/event_resource.go
+++ b/sdk/client/event_resource.go
@@ -12,12 +12,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
 // Linger please

--- a/sdk/client/health_check_resource.go
+++ b/sdk/client/health_check_resource.go
@@ -11,10 +11,11 @@ package client
 
 import (
 	"context"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
 // Linger please

--- a/sdk/client/metadata_resource.go
+++ b/sdk/client/metadata_resource.go
@@ -12,13 +12,13 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 
 	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
 // Linger please

--- a/sdk/client/task_resource.go
+++ b/sdk/client/task_resource.go
@@ -12,12 +12,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
 // Linger please
@@ -94,7 +94,7 @@ func (a *TaskResourceApiService) All(ctx context.Context) (map[string]int64, *ht
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
-			error: localVarHttpResponse.Status,
+			error: string(localVarBody),
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string]int64
@@ -177,7 +177,7 @@ func (a *TaskResourceApiService) AllVerbose(ctx context.Context) (map[string]map
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
-			error: localVarHttpResponse.Status,
+			error: string(localVarBody),
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string]map[string]map[string]int64
@@ -287,7 +287,7 @@ func (a *TaskResourceApiService) BatchPoll(ctx context.Context, tasktype string,
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
-			error: localVarHttpResponse.Status,
+			error: string(localVarBody),
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.Task
@@ -370,7 +370,7 @@ func (a *TaskResourceApiService) GetAllPollData(ctx context.Context) ([]model.Po
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
-			error: localVarHttpResponse.Status,
+			error: string(localVarBody),
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.PollData
@@ -459,7 +459,7 @@ func (a *TaskResourceApiService) GetExternalStorageLocation1(ctx context.Context
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
 			body:  localVarBody,
-			error: localVarHttpResponse.Status,
+			error: string(localVarBody),
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.ExternalStorageLocation

--- a/sdk/client/workflow_bulk_resource.go
+++ b/sdk/client/workflow_bulk_resource.go
@@ -11,12 +11,12 @@ package client
 
 import (
 	"context"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
 // Linger please

--- a/sdk/client/workflow_resource.go
+++ b/sdk/client/workflow_resource.go
@@ -12,12 +12,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/conductor-sdk/conductor-go/sdk/model"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/antihax/optional"
+	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
 // Linger please


### PR DESCRIPTION
New behavior example:
```
{"level":"error","msg":"Failed to poll and execute, reason: {\"status\":400,\"message\":\"Long Poll Timeout value cannot be more than 5 seconds\",\"instance\":\"orkes-conductor-deployment-86dd58c895-l57gg\",\"retryable\":false}, taskName: TEST_GO_TASK_SIMPLE, domain: ","time":"2022-07-26T22:23:07-03:00"}
```