### PR TITLE
NOTASK - terminate workflow API - add triggerFailureWorkflow flag

### DIFF
--- a/docs/executor.md
+++ b/docs/executor.md
@@ -272,10 +272,11 @@ StartWorkflows Start workflows in bulk Returns RunningWorkflow struct that conta
 ### func \(\*WorkflowExecutor\) [Terminate](<https://github.com/conductor-sdk/conductor-go/blob/main/sdk/workflow/executor/executor.go#L293>)
 
 ```go
-func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error
+func (e *WorkflowExecutor) Terminate(workflowId string, reason string, triggerFailureWorkflow bool) error
 ```
 
-Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow
+Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow.
+triggerFailureWorkflow is a boolean flag which when set to true will trigger failureWorkflow upon termination, if avaliable.
 
 ### func \(\*WorkflowExecutor\) [UpdateTask](<https://github.com/conductor-sdk/conductor-go/blob/main/sdk/workflow/executor/executor.go#L366>)
 

--- a/docs/executor.md
+++ b/docs/executor.md
@@ -272,7 +272,13 @@ StartWorkflows Start workflows in bulk Returns RunningWorkflow struct that conta
 ### func \(\*WorkflowExecutor\) [Terminate](<https://github.com/conductor-sdk/conductor-go/blob/main/sdk/workflow/executor/executor.go#L293>)
 
 ```go
-func (e *WorkflowExecutor) Terminate(workflowId string, reason string, triggerFailureWorkflow bool) error
+func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error
+```
+
+Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow.
+
+```go
+func (e *WorkflowExecutor) TerminateWithFailure(workflowId string, reason string, triggerFailureWorkflow bool) error
 ```
 
 Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow.

--- a/sdk/client/workflow_bulk_resource.go
+++ b/sdk/client/workflow_bulk_resource.go
@@ -392,7 +392,8 @@ WorkflowBulkResourceApiService Terminate workflows execution
 */
 
 type WorkflowBulkResourceApiTerminateOpts struct {
-	Reason optional.String
+	Reason                 optional.String
+	TriggerFailureWorkflow optional.Bool
 }
 
 func (a *WorkflowBulkResourceApiService) Terminate(ctx context.Context, body []string, localVarOptionals *WorkflowBulkResourceApiTerminateOpts) (model.BulkResponse, *http.Response, error) {
@@ -413,6 +414,10 @@ func (a *WorkflowBulkResourceApiService) Terminate(ctx context.Context, body []s
 
 	if localVarOptionals != nil && localVarOptionals.Reason.IsSet() {
 		localVarQueryParams.Add("reason", parameterToString(localVarOptionals.Reason.Value(), ""))
+	}
+
+	if localVarOptionals != nil && localVarOptionals.TriggerFailureWorkflow.IsSet() {
+		localVarQueryParams.Add("triggerFailureWorkflow", parameterToString(localVarOptionals.TriggerFailureWorkflow.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}

--- a/sdk/client/workflow_resource.go
+++ b/sdk/client/workflow_resource.go
@@ -2086,7 +2086,8 @@ WorkflowResourceApiService Terminate workflow execution
 */
 
 type WorkflowResourceApiTerminateOpts struct {
-	Reason optional.String
+	Reason                 optional.String
+	TriggerFailureWorkflow optional.Bool
 }
 
 func (a *WorkflowResourceApiService) Terminate(ctx context.Context, workflowId string, localVarOptionals *WorkflowResourceApiTerminateOpts) (*http.Response, error) {
@@ -2107,6 +2108,10 @@ func (a *WorkflowResourceApiService) Terminate(ctx context.Context, workflowId s
 
 	if localVarOptionals != nil && localVarOptionals.Reason.IsSet() {
 		localVarQueryParams.Add("reason", parameterToString(localVarOptionals.Reason.Value(), ""))
+	}
+
+	if localVarOptionals != nil && localVarOptionals.TriggerFailureWorkflow.IsSet() {
+		localVarQueryParams.Add("triggerFailureWorkflow", parameterToString(localVarOptionals.TriggerFailureWorkflow.Value(), ""))
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}

--- a/sdk/workflow/executor/executor.go
+++ b/sdk/workflow/executor/executor.go
@@ -310,7 +310,17 @@ func (e *WorkflowExecutor) Resume(workflowId string) error {
 }
 
 // Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow
-func (e *WorkflowExecutor) Terminate(workflowId string, reason string, triggerFailureWorkflow bool) error {
+func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error {
+	_, err := e.workflowClient.Terminate(context.Background(), workflowId,
+		&client.WorkflowResourceApiTerminateOpts{Reason: optional.NewString(reason), TriggerFailureWorkflow: optional.NewBool(false)},
+	)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (e *WorkflowExecutor) TerminateWithFailure(workflowId string, reason string, triggerFailureWorkflow bool) error {
 	_, err := e.workflowClient.Terminate(context.Background(), workflowId,
 		&client.WorkflowResourceApiTerminateOpts{Reason: optional.NewString(reason), TriggerFailureWorkflow: optional.NewBool(triggerFailureWorkflow)},
 	)

--- a/sdk/workflow/executor/executor.go
+++ b/sdk/workflow/executor/executor.go
@@ -310,9 +310,9 @@ func (e *WorkflowExecutor) Resume(workflowId string) error {
 }
 
 // Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow
-func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error {
+func (e *WorkflowExecutor) Terminate(workflowId string, reason string, triggerFailureWorkflow bool) error {
 	_, err := e.workflowClient.Terminate(context.Background(), workflowId,
-		&client.WorkflowResourceApiTerminateOpts{Reason: optional.NewString(reason)},
+		&client.WorkflowResourceApiTerminateOpts{Reason: optional.NewString(reason), TriggerFailureWorkflow: optional.NewBool(triggerFailureWorkflow)},
 	)
 	if err != nil {
 		return err

--- a/sdk/workflow/executor/executor.go
+++ b/sdk/workflow/executor/executor.go
@@ -11,10 +11,12 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -311,6 +313,11 @@ func (e *WorkflowExecutor) Resume(workflowId string) error {
 
 // Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow
 func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error {
+	if strings.TrimSpace(workflowId) == "" {
+		err := errors.New("workflow id cannot be empty when calling terminate workflow API")
+		log.Error("Failed to terminate workflow: ", err.Error())
+		return err
+	}
 	_, err := e.workflowClient.Terminate(context.Background(), workflowId,
 		&client.WorkflowResourceApiTerminateOpts{Reason: optional.NewString(reason), TriggerFailureWorkflow: optional.NewBool(false)},
 	)
@@ -321,6 +328,11 @@ func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error {
 }
 
 func (e *WorkflowExecutor) TerminateWithFailure(workflowId string, reason string, triggerFailureWorkflow bool) error {
+	if strings.TrimSpace(workflowId) == "" {
+		err := errors.New("workflow id cannot be empty when calling terminate workflow API")
+		log.Error("Failed to terminate workflow: ", err.Error())
+		return err
+	}
 	_, err := e.workflowClient.Terminate(context.Background(), workflowId,
 		&client.WorkflowResourceApiTerminateOpts{Reason: optional.NewString(reason), TriggerFailureWorkflow: optional.NewBool(triggerFailureWorkflow)},
 	)


### PR DESCRIPTION
When set to true, failureWorkflow will be triggered upon termination, if available