### PR TITLE
Fix race which does not honor batch size in worker

### DIFF
--- a/sdk/worker/task_runner.go
+++ b/sdk/worker/task_runner.go
@@ -287,12 +287,12 @@ func (c *TaskRunner) workOnce(taskName string, executeFunction model.ExecuteTask
 		return
 	}
 	for _, task := range tasks {
+		c.increaseRunningWorkers(taskName)
 		go c.executeAndUpdateTask(taskName, task, executeFunction)
 	}
 }
 
 func (c *TaskRunner) executeAndUpdateTask(taskName string, task model.Task, executeFunction model.ExecuteTaskFunction) {
-	c.increaseRunningWorkers(taskName)
 	defer c.runningWorkerDone(taskName)
 	defer concurrency.HandlePanicError("execute_and_update_task " + string(task.TaskId) + ": " + string(task.Status))
 	taskResult := c.executeTask(&task, executeFunction)


### PR DESCRIPTION
Issue:

Even though batch size is set as 1. Noticed that 2 tasks were dequeued by the worker.

RCA:

There is a race between getAvailableWorkerAmount() and executeAndUpdateTask() in workOnce() code. Here are the sequence of events:

BATCH_SIZE is set to 1 in my case.

1. More than 1 tasks are present in the work queue.
2. Worker is started and a task is dequeued.
3. executeAndUpdateTask() is spawned in a go routine. However workOnce immediately checks for getAvailableWorkerAmount().
4. The go routine hasn't had a chance to run yet and workOnce ends up dequeuing another task.

Fix:

Update  c.increaseRunningWorkers() in workOnce() rather than inside the go routine for executeAndUpdateTask(). This ensures that getAvailableWorkerAmount() always returns the right value and we can avoid dequeuing additional tasks  (more than batchSize).

Note: From what I can read, it seems like the Java SDK client has moved away from this design and using TaskRunnerConfig to poll for tasks. I realize the go client isn't quite there yet. This is a simple fix which unblocks my work for the time being. I also notice some other draft PRs which are reworking this logic. However I was not sure if they addressed this particular race or not.