### PR TITLE
bugfix: fix panic

### DIFF
--- a/sdk/workflow/executor/executor.go
+++ b/sdk/workflow/executor/executor.go
@@ -210,6 +210,9 @@ func (e *WorkflowExecutor) getWorkflow(retry int, workflowId string, includeTask
 		&client.WorkflowResourceApiGetExecutionStatusOpts{
 			IncludeTasks: optional.NewBool(includeTasks)},
 	)
+	if err != nil {
+		return nil, err
+	}
 	if response.StatusCode == 404 {
 		return nil, fmt.Errorf("no such workflow by Id %s", workflowId)
 	}


### PR DESCRIPTION
```
github.com/conductor-sdk/conductor-go/sdk/workflow/executor.(*WorkflowExecutor).getWorkflow(0xc000066dc0, 0x4, {0xc002b52330, 0x24}, 0x1) 
/Users/xxxx/go1.19/global/pkg/mod/github.com/conductor-sdk/conductor-go@v1.3.7/sdk/workflow/executor/executor.go:213 +0x18e 
github.com/conductor-sdk/conductor-go/sdk/workflow/executor.(*WorkflowExecutor).GetWorkflow(...)
```