### PR TITLE
📝 Cant run worker without wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ var (
 
 func StartWorkers() {
 	taskRunner.StartWorker("greet", greet.Greet, 1, time.Millisecond*100)
+	taskRunner.WaitWorkers()
 }
 
 func main() {


### PR DESCRIPTION
Without `taskRunner.WaitWorkers()`, I dont think you can call the example "working".

I believe every user is puzzled after first run to find `taskRunner.WaitWorkers()` deeper in the docs `N` minutes later. Id be embarrassed to admit my `N` value 🙃