### PR TITLE
Fix Switch Task's `toWorkflowTask` 

### DIFF
--- a/sdk/workflow/switch.go
+++ b/sdk/workflow/switch.go
@@ -109,6 +109,11 @@ func (task *SwitchTask) Optional(optional bool) *SwitchTask {
 // If set to false, the caseExpression follows the regular task input mapping format as described in https://conductor.netflix.com/how-tos/Tasks/task-inputs.html
 func (task *SwitchTask) UseJavascript(use bool) *SwitchTask {
 	task.useJavascript = use
-	task.evaluatorType = EvaluatorTypeJavaScript
+	if use {
+		task.evaluatorType = EvaluatorTypeJavaScript
+	} else {
+		task.evaluatorType = EvaluatorTypeValueParam
+	}
+
 	return task
 }

--- a/sdk/workflow/switch_test.go
+++ b/sdk/workflow/switch_test.go
@@ -1,0 +1,75 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToWorkflowTaskValueParamEvaluator(t *testing.T) {
+	caseExpr := "${workflow.input.notificationPref}"
+	task := NewSwitchTask("emailorsms", caseExpr).
+		SwitchCase("EMAIL", createSendEmailTask()).
+		SwitchCase("SMS", createSendSMSTask())
+
+	wfTasks := task.toWorkflowTask()
+
+	// toWorkflowTask doesn't modify the task
+	assert.Equal(t, caseExpr, task.expression)
+	assert.False(t, task.useJavascript)
+	assert.Len(t, task.inputParameters, 0)
+	assert.Len(t, task.defaultCase, 0)
+	assert.Len(t, task.DecisionCases, 2)
+
+	// workflowTask instances
+	assert.Len(t, wfTasks, 1)
+
+	wfTask := wfTasks[0]
+	assert.Equal(t, "value-param", wfTask.EvaluatorType)
+	assert.Equal(t, "switchCaseValue", wfTask.Expression)
+	assert.Len(t, wfTask.InputParameters, 1)
+	assert.Equal(t, caseExpr, wfTask.InputParameters["switchCaseValue"])
+	assert.Len(t, wfTask.DefaultCase, 0)
+	assert.Len(t, wfTask.DecisionCases, 2)
+	assert.NotNil(t, wfTask.DecisionCases["EMAIL"])
+	assert.NotNil(t, wfTask.DecisionCases["SMS"])
+}
+
+func TestToWorkflowTaskJSEvaluator(t *testing.T) {
+	caseExpr := "${workflow.input.notificationPref}"
+	task := NewSwitchTask("emailorsms", caseExpr).
+		SwitchCase("EMAIL", createSendEmailTask()).
+		SwitchCase("SMS", createSendSMSTask()).
+		UseJavascript(true)
+
+	wfTasks := task.toWorkflowTask()
+
+	// toWorkflowTask doesn't modify the task
+	assert.Equal(t, caseExpr, task.expression)
+	assert.True(t, task.useJavascript)
+	assert.Len(t, task.inputParameters, 0)
+	assert.Len(t, task.defaultCase, 0)
+	assert.Len(t, task.DecisionCases, 2)
+
+	// workflowTask instances
+	assert.Len(t, wfTasks, 1)
+
+	wfTask := wfTasks[0]
+	assert.Equal(t, "javascript", wfTask.EvaluatorType)
+	assert.Equal(t, caseExpr, wfTask.Expression)
+	assert.Len(t, wfTask.InputParameters, 0)
+	assert.Len(t, wfTask.DefaultCase, 0)
+	assert.Len(t, wfTask.DecisionCases, 2)
+	assert.NotNil(t, wfTask.DecisionCases["EMAIL"])
+	assert.NotNil(t, wfTask.DecisionCases["SMS"])
+}
+
+func createSendEmailTask() TaskInterface {
+	return NewSimpleTask("send_email", "send_email").
+		Input("email", "${get_user_info.output.email}")
+}
+
+func createSendSMSTask() TaskInterface {
+	return NewSimpleTask("send_sms", "send_sms").
+		Input("phoneNumber", "${get_user_info.output.phoneNumber}")
+}

--- a/sdk/workflow/switch_test.go
+++ b/sdk/workflow/switch_test.go
@@ -64,6 +64,21 @@ func TestToWorkflowTaskJSEvaluator(t *testing.T) {
 	assert.NotNil(t, wfTask.DecisionCases["SMS"])
 }
 
+func TestUseJavascript(t *testing.T) {
+	task := NewSwitchTask("switch", "caseExpr")
+
+	assert.False(t, task.useJavascript)
+	assert.Equal(t, "value-param", task.evaluatorType)
+
+	task.UseJavascript(true)
+	assert.True(t, task.useJavascript)
+	assert.Equal(t, "javascript", task.evaluatorType)
+
+	task.UseJavascript(false)
+	assert.False(t, task.useJavascript)
+	assert.Equal(t, "value-param", task.evaluatorType)
+}
+
 func createSendEmailTask() TaskInterface {
 	return NewSimpleTask("send_email", "send_email").
 		Input("email", "${get_user_info.output.email}")

--- a/sdk/workflow/task.go
+++ b/sdk/workflow/task.go
@@ -11,6 +11,7 @@ package workflow
 
 import (
 	"fmt"
+
 	"github.com/conductor-sdk/conductor-go/sdk/model"
 )
 
@@ -69,13 +70,18 @@ type Task struct {
 }
 
 func (task *Task) toWorkflowTask() []model.WorkflowTask {
+	// copy input params so that Task's params are not modified
+	inputParams := make(map[string]interface{})
+	for key, value := range task.inputParameters {
+		inputParams[key] = value
+	}
 
 	return []model.WorkflowTask{
 		{
 			Name:              task.name,
 			TaskReferenceName: task.taskReferenceName,
 			Description:       task.description,
-			InputParameters:   task.inputParameters,
+			InputParameters:   inputParams,
 			Optional:          task.optional,
 			Type_:             string(task.taskType),
 		},

--- a/test/integration_tests/integration_client_test.go
+++ b/test/integration_tests/integration_client_test.go
@@ -2,12 +2,13 @@ package integration_tests
 
 import (
 	"context"
+	"testing"
+
 	"github.com/antihax/optional"
 	"github.com/conductor-sdk/conductor-go/internal/testdata"
 	"github.com/conductor-sdk/conductor-go/sdk/client"
 	"github.com/conductor-sdk/conductor-go/sdk/model/integration"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestIntegrationClient(t *testing.T) {
@@ -49,14 +50,12 @@ func TestIntegrationClient(t *testing.T) {
 	require.NoError(t, err, "error fetching integration providers")
 	require.NotNil(t, resp, "response should not be nil for GetIntegrationProviders")
 	require.Greater(t, len(providers), len(integrationEntries), "the number of providers fetched should match the entries inserted")
-	t.Logf("Fetched all providers: %+v", providers)
 
 	// Testing GetIntegrationProvider for each inserted entry
 	for i, entry := range integrationEntries {
 		provider, resp, err := integrationClient.GetIntegrationProvider(ctx, names[i])
 		require.NoError(t, err, "error fetching a specific integration provider")
 		require.NotNil(t, resp, "response should not be nil for GetIntegrationProvider")
-		t.Logf("Fetched provider (%s): %+v", entry.Type_, provider)
 		require.Equal(t, entry.Category, provider.Category, "category should match the inserted provider")
 	}
 

--- a/test/integration_tests/workflow_def_test.go
+++ b/test/integration_tests/workflow_def_test.go
@@ -11,7 +11,6 @@ package integration_tests
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"testing"
 
@@ -323,7 +322,6 @@ func countMultipleSwitchInnerTasks(tasks ...model.WorkflowTask) int {
 }
 
 func countSwitchInnerTasks(task model.WorkflowTask) int {
-	fmt.Println(task.Type_)
 	counter := 1
 	if task.Type_ != "SWITCH" {
 		return counter


### PR DESCRIPTION
- Don't modify the task's values (it's overwriting `task.expression` with  `"switchCaseValue"`).
- Copy `task.inputParameters` when creating `model.WorkflowTask` instance.
- Minor refactoring: use const, use variadic operator to unpack slice instead of for.