### PR TITLE
Add test for breaking change in `v1.3.9`

### DIFF
--- a/sdk/workflow/http_test.go
+++ b/sdk/workflow/http_test.go
@@ -1,0 +1,55 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHttpTaskHasNoInlineTaskDef(t *testing.T) {
+	input := &HttpInput{
+		Method: GET,
+		Uri:    "http://example.com",
+	}
+	task := NewHttpTask("http_task_ref", input)
+	wfTasks := task.toWorkflowTask()
+
+	wfTask := wfTasks[0]
+	assert.Nil(t, wfTask.TaskDefinition)
+}
+
+func TestHttpTaskTaskDefMapping(t *testing.T) {
+	task := NewHttpTask("http_task_ref", &HttpInput{
+		Method: POST,
+		Uri:    "http://example.com/api",
+	})
+
+	task.CacheConfig("cacheKey", 7200)
+	task.RetryPolicy(5, "EXPONENTIAL_BACKOFF", 15, 3)
+	task.RateLimitFrequency(120, 10)
+	task.ConcurrentExecutionLimit(20)
+	task.ExecutionTimeout(600)
+	task.PollTimeout(180)
+	task.ResponseTimeout(1200)
+	task.TimeoutPolicy("TIMEOUT_FAILURE")
+
+	wfTasks := task.toWorkflowTask()
+	wfTask := wfTasks[0]
+
+	// Check if TaskDefinition is set correctly
+	assert.NotNil(t, wfTask.TaskDefinition)
+
+	// Assertions for task definition mappings
+	taskDef := wfTask.TaskDefinition
+	assert.Equal(t, int32(5), taskDef.RetryCount)
+	assert.Equal(t, "EXPONENTIAL_BACKOFF", taskDef.RetryLogic)
+	assert.Equal(t, int32(15), taskDef.RetryDelaySeconds)
+	assert.Equal(t, int32(3), taskDef.BackoffScaleFactor)
+	assert.Equal(t, int32(120), taskDef.RateLimitFrequencyInSeconds)
+	assert.Equal(t, int32(10), taskDef.RateLimitPerFrequency)
+	assert.Equal(t, int32(20), taskDef.ConcurrentExecLimit)
+	assert.Equal(t, int64(600), taskDef.TimeoutSeconds)
+	assert.Equal(t, int32(180), taskDef.PollTimeoutSeconds)
+	assert.Equal(t, int64(1200), taskDef.ResponseTimeoutSeconds)
+	assert.Equal(t, "TIMEOUT_FAILURE", taskDef.TimeoutPolicy)
+}

--- a/sdk/workflow/simple_test.go
+++ b/sdk/workflow/simple_test.go
@@ -1,0 +1,47 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleTaskHasNoInlineTaskDef(t *testing.T) {
+	task := NewSimpleTask("simple", "simple_ref")
+	wfTasks := task.toWorkflowTask()
+
+	wfTask := wfTasks[0]
+	assert.Nil(t, wfTask.TaskDefinition)
+}
+
+func TestSimpleTaskTaskDefMapping(t *testing.T) {
+	task := NewSimpleTask("simple", "simple_ref")
+
+	task.CacheConfig("cacheKey", 3600)
+	task.RetryPolicy(3, "FIXED", 10, 2)
+	task.RateLimitFrequency(60, 5)
+	task.ConcurrentExecutionLimit(10)
+	task.ExecutionTimeout(300)
+	task.PollTimeout(120)
+	task.ResponseTimeout(600)
+	task.TimeoutPolicy("RETRY")
+
+	wfTasks := task.toWorkflowTask()
+	wfTask := wfTasks[0]
+
+	assert.NotNil(t, wfTask.TaskDefinition)
+
+	// Assertions for task definition mappings
+	taskDef := wfTask.TaskDefinition
+	assert.Equal(t, int32(3), taskDef.RetryCount)
+	assert.Equal(t, "FIXED", taskDef.RetryLogic)
+	assert.Equal(t, int32(10), taskDef.RetryDelaySeconds)
+	assert.Equal(t, int32(2), taskDef.BackoffScaleFactor)
+	assert.Equal(t, int32(60), taskDef.RateLimitFrequencyInSeconds)
+	assert.Equal(t, int32(5), taskDef.RateLimitPerFrequency)
+	assert.Equal(t, int32(10), taskDef.ConcurrentExecLimit)
+	assert.Equal(t, int64(300), taskDef.TimeoutSeconds)
+	assert.Equal(t, int32(120), taskDef.PollTimeoutSeconds)
+	assert.Equal(t, int64(600), taskDef.ResponseTimeoutSeconds)
+	assert.Equal(t, "RETRY", taskDef.TimeoutPolicy)
+}


### PR DESCRIPTION
## Changes in this PR

- Test no default inline task definition is added.
- Test task definition mappings.

I'm adding the tests that I requested in [PR #147](https://github.com/conductor-sdk/conductor-go/pull/147). 

Unfortunately, they were not included before that PR was merged.  As a best practice, we should aim to include tests with any fix or new feature, especially in scenarios as testable as this one.


