### PR TITLE
Run workflow with tests after a successful build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: >
+          DOCKER_BUILDKIT=1 docker build
+          --progress=plain
+          --target=build          
+          .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,18 @@
-name: Continuous Integration
+name: Tests
 
-on: [push, pull_request]
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
-  build-and-test:
+  tests:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Build
-        run: >
-          DOCKER_BUILDKIT=1 docker build
-          --progress=plain
-          --target=build          
-          .
       - name: Test
         run: >
           DOCKER_BUILDKIT=1 docker build


### PR DESCRIPTION
Tests are going to run in a different workflow triggered after a successful build.

The reason for doing this is that we have integration tests which use credentials and secrets are not available to builds triggered by PRs from forked repositories. This causes community contributions to fail. 

The Build workflow does not use secrets and serves as a gatekeeper.