### PR TITLE
FIX: Tests should run in head branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,5 +19,5 @@ jobs:
         run: >
           DOCKER_BUILDKIT=1 docker build
           --progress=plain
-          --target=build          
+          --target=build
           .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
       - name: Test
         run: >
           DOCKER_BUILDKIT=1 docker build
@@ -20,5 +22,5 @@ jobs:
           --build-arg KEY=${{ secrets.KEY }}
           --build-arg SECRET=${{ secrets.SECRET }}
           --build-arg CONDUCTOR_SERVER_URL=${{ secrets.CONDUCTOR_SERVER_URL }}
-          --target=test          
+          --target=test
           .


### PR DESCRIPTION
With https://github.com/conductor-sdk/conductor-go/pull/149 changes the tests (including integration tests) run on PRs from forked repos.

However, I missed this in the checkout, so they are running on `main`.

```
with:
      ref: ${{ github.event.workflow_run.head_branch }}
```