### PR TITLE
Unit test run on build + fix checkout in integration tests workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,3 +21,9 @@ jobs:
           --progress=plain
           --target=build
           .
+      - name: Test
+        run: >
+          DOCKER_BUILDKIT=1 docker build
+          --progress=plain
+          --target=test
+          .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,20 +7,22 @@ on:
       - completed
 
 jobs:
-  tests:
+  integration-tests:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-      - name: Test
+          ref: ${{ github.event.workflow_run.head_sha }}
+          repository: ${{ github.event.workflow_run.repository.full_name }}
+      - name: Run Integration Tests
+        id: integration_test
         run: >
           DOCKER_BUILDKIT=1 docker build
           --progress=plain
           --build-arg KEY=${{ secrets.KEY }}
           --build-arg SECRET=${{ secrets.SECRET }}
           --build-arg CONDUCTOR_SERVER_URL=${{ secrets.CONDUCTOR_SERVER_URL }}
-          --target=test
+          --target=inttest
           .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,3 +26,33 @@ jobs:
           --build-arg CONDUCTOR_SERVER_URL=${{ secrets.CONDUCTOR_SERVER_URL }}
           --target=inttest
           .
+      - name: Set PR Status to Failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            await github.rest.repos.createCommitStatus({
+              owner: owner,
+              repo: repo,
+              sha: sha,
+              state: 'failure',
+              context: 'Integration Tests',
+              description: 'Integration tests failed.',
+            });
+      - name: Set PR Status to Success
+        if: ${{ success() }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.payload.workflow_run.head_sha;
+            await github.rest.repos.createCommitStatus({
+              owner: owner,
+              repo: repo,
+              sha: sha,
+              state: 'success',
+              context: 'Integration Tests',
+              description: 'Integration tests succeeded.',
+            });

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,14 @@ RUN go build -v ./...
 
 FROM build as test
 COPY /test /package/test
+RUN go test -v $(go list ./... | grep -v /test/integration_tests)
+
+FROM build as inttest
+COPY /test /package/test
 ARG KEY
 ARG SECRET
 ARG CONDUCTOR_SERVER_URL
 ENV KEY=${KEY}
 ENV SECRET=${SECRET}
 ENV CONDUCTOR_SERVER_URL=${CONDUCTOR_SERVER_URL}
-RUN go test -v ./...
+RUN go test -v ./test/integration_tests/...


### PR DESCRIPTION
## Changes in this PR

- Unit tests are run with build workflow.
- Integration tests are run after (different workflow).
- Fixed checkout from remote branch.
- Fail PR if integration tests fail.

Tested this in a different repo.

![image](https://github.com/user-attachments/assets/df2a2aca-ca25-47d9-bb50-7721803fe3be)

 

Follow up of these 2 other:
- https://github.com/conductor-sdk/conductor-go/pull/149
- https://github.com/conductor-sdk/conductor-go/pull/151

