### PR TITLE
Enhance API error details 

### DIFF
--- a/sdk/client/api_application_resource.go
+++ b/sdk/client/api_application_resource.go
@@ -91,10 +91,7 @@ func (a *ApplicationResourceApiService) AddRoleToApplicationUser(ctx context.Con
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -176,10 +173,7 @@ func (a *ApplicationResourceApiService) CreateAccessKey(ctx context.Context, id 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return nil, httpResponse, newErr
 	}
 
@@ -252,10 +246,7 @@ func (a *ApplicationResourceApiService) CreateApplication(ctx context.Context, b
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return nil, httpResponse, newErr
 	}
 
@@ -329,10 +320,7 @@ func (a *ApplicationResourceApiService) DeleteAccessKey(ctx context.Context, app
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -404,10 +392,7 @@ func (a *ApplicationResourceApiService) DeleteApplication(ctx context.Context, i
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -482,10 +467,7 @@ func (a *ApplicationResourceApiService) DeleteTagForApplication(ctx context.Cont
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -557,10 +539,7 @@ func (a *ApplicationResourceApiService) GetAccessKeys(ctx context.Context, id st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return returnValue, httpResponse, newErr
 	}
 
@@ -632,10 +611,7 @@ func (a *ApplicationResourceApiService) GetAppByAccessKeyId(ctx context.Context,
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -717,10 +693,7 @@ func (a *ApplicationResourceApiService) GetApplication(ctx context.Context, id s
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return nil, httpResponse, newErr
 	}
 
@@ -792,10 +765,7 @@ func (a *ApplicationResourceApiService) GetTagsForApplication(ctx context.Contex
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Tag
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -875,10 +845,7 @@ func (a *ApplicationResourceApiService) ListApplications(ctx context.Context) ([
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []rbac.ConductorApplication
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -953,10 +920,7 @@ func (a *ApplicationResourceApiService) PutTagForApplication(ctx context.Context
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -1030,10 +994,7 @@ func (a *ApplicationResourceApiService) RemoveRoleFromApplicationUser(ctx contex
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1117,10 +1078,7 @@ func (a *ApplicationResourceApiService) ToggleAccessKeyStatus(ctx context.Contex
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1205,10 +1163,7 @@ func (a *ApplicationResourceApiService) UpdateApplication(ctx context.Context, b
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return nil, httpResponse, newErr
 	}
 

--- a/sdk/client/api_application_resource.go
+++ b/sdk/client/api_application_resource.go
@@ -92,16 +92,6 @@ func (a *ApplicationResourceApiService) AddRoleToApplicationUser(ctx context.Con
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -393,16 +383,6 @@ func (a *ApplicationResourceApiService) DeleteApplication(ctx context.Context, i
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -612,16 +592,6 @@ func (a *ApplicationResourceApiService) GetAppByAccessKeyId(ctx context.Context,
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -766,16 +736,6 @@ func (a *ApplicationResourceApiService) GetTagsForApplication(ctx context.Contex
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Tag
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -846,16 +806,6 @@ func (a *ApplicationResourceApiService) ListApplications(ctx context.Context) ([
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []rbac.ConductorApplication
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -995,16 +945,6 @@ func (a *ApplicationResourceApiService) RemoveRoleFromApplicationUser(ctx contex
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -1079,16 +1019,6 @@ func (a *ApplicationResourceApiService) ToggleAccessKeyStatus(ctx context.Contex
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_authorization_resource.go
+++ b/sdk/client/api_authorization_resource.go
@@ -91,16 +91,6 @@ func (a *AuthorizationResourceApiService) GetPermissions(ctx context.Context, ty
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -169,7 +159,6 @@ func (a *AuthorizationResourceApiService) GrantPermissions(ctx context.Context, 
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-
 		return httpResponse, newErr
 	}
 
@@ -238,7 +227,6 @@ func (a *AuthorizationResourceApiService) RemovePermissions(ctx context.Context,
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-
 		return httpResponse, newErr
 	}
 

--- a/sdk/client/api_authorization_resource.go
+++ b/sdk/client/api_authorization_resource.go
@@ -90,10 +90,7 @@ func (a *AuthorizationResourceApiService) GetPermissions(ctx context.Context, ty
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -171,10 +168,7 @@ func (a *AuthorizationResourceApiService) GrantPermissions(ctx context.Context, 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 
 		return httpResponse, newErr
 	}
@@ -243,10 +237,7 @@ func (a *AuthorizationResourceApiService) RemovePermissions(ctx context.Context,
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 
 		return httpResponse, newErr
 	}

--- a/sdk/client/api_environment_resource.go
+++ b/sdk/client/api_environment_resource.go
@@ -82,10 +82,7 @@ func (a *EnvironmentResourceApiService) CreateOrUpdateEnvVariable(ctx context.Co
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -157,10 +154,7 @@ func (a *EnvironmentResourceApiService) DeleteEnvVariable(ctx context.Context, k
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -235,10 +229,7 @@ func (a *EnvironmentResourceApiService) DeleteTagForEnvVar(ctx context.Context, 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -310,10 +301,7 @@ func (a *EnvironmentResourceApiService) Get(ctx context.Context, key string) (st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -393,10 +381,7 @@ func (a *EnvironmentResourceApiService) GetAll(ctx context.Context) ([]model.Env
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.EnvironmentVariable
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -478,10 +463,7 @@ func (a *EnvironmentResourceApiService) GetTagsForEnvVar(ctx context.Context, na
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Tag
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -556,10 +538,7 @@ func (a *EnvironmentResourceApiService) PutTagForEnvVar(ctx context.Context, bod
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 

--- a/sdk/client/api_environment_resource.go
+++ b/sdk/client/api_environment_resource.go
@@ -155,16 +155,6 @@ func (a *EnvironmentResourceApiService) DeleteEnvVariable(ctx context.Context, k
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -302,16 +292,6 @@ func (a *EnvironmentResourceApiService) Get(ctx context.Context, key string) (st
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -382,16 +362,6 @@ func (a *EnvironmentResourceApiService) GetAll(ctx context.Context) ([]model.Env
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.EnvironmentVariable
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -464,16 +434,6 @@ func (a *EnvironmentResourceApiService) GetTagsForEnvVar(ctx context.Context, na
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Tag
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_group_resource.go
+++ b/sdk/client/api_group_resource.go
@@ -91,16 +91,6 @@ func (a *GroupResourceApiService) AddUserToGroup(ctx context.Context, groupId st
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -305,16 +295,6 @@ func (a *GroupResourceApiService) GetGrantedPermissions1(ctx context.Context, gr
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v rbac.GrantedAccessResponse
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -387,16 +367,6 @@ func (a *GroupResourceApiService) GetGroup(ctx context.Context, id string) (inte
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -469,16 +439,6 @@ func (a *GroupResourceApiService) GetUsersInGroup(ctx context.Context, id string
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -549,16 +509,6 @@ func (a *GroupResourceApiService) ListGroups(ctx context.Context) ([]rbac.Group,
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []rbac.Group
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -633,16 +583,6 @@ func (a *GroupResourceApiService) RemoveUserFromGroup(ctx context.Context, group
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -783,16 +723,6 @@ func (a *GroupResourceApiService) UpsertGroup(ctx context.Context, body rbac.Ups
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_group_resource.go
+++ b/sdk/client/api_group_resource.go
@@ -90,10 +90,7 @@ func (a *GroupResourceApiService) AddUserToGroup(ctx context.Context, groupId st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -168,10 +165,7 @@ func (a *GroupResourceApiService) AddUsersToGroup(ctx context.Context, body []st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -238,10 +232,7 @@ func (a *GroupResourceApiService) DeleteGroup(ctx context.Context, id string) (*
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -313,10 +304,7 @@ func (a *GroupResourceApiService) GetGrantedPermissions1(ctx context.Context, gr
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v rbac.GrantedAccessResponse
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -398,10 +386,7 @@ func (a *GroupResourceApiService) GetGroup(ctx context.Context, id string) (inte
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -483,10 +468,7 @@ func (a *GroupResourceApiService) GetUsersInGroup(ctx context.Context, id string
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -566,10 +548,7 @@ func (a *GroupResourceApiService) ListGroups(ctx context.Context) ([]rbac.Group,
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []rbac.Group
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -653,10 +632,7 @@ func (a *GroupResourceApiService) RemoveUserFromGroup(ctx context.Context, group
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -731,10 +707,7 @@ func (a *GroupResourceApiService) RemoveUsersFromGroup(ctx context.Context, body
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -809,10 +782,7 @@ func (a *GroupResourceApiService) UpsertGroup(ctx context.Context, body rbac.Ups
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_human_task.go
+++ b/sdk/client/api_human_task.go
@@ -106,10 +106,7 @@ func (a *HumanTaskApiService) AssignAndClaim(ctx context.Context, taskId string,
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskEntry
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -191,10 +188,7 @@ func (a *HumanTaskApiService) BackPopulateFullTextIndex(ctx context.Context, var
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v map[string]interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -291,10 +285,7 @@ func (a *HumanTaskApiService) ClaimTask(ctx context.Context, taskId string, opti
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskEntry
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -367,10 +358,7 @@ func (a *HumanTaskApiService) DeleteTaskFromHumanTaskRecords(ctx context.Context
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -432,10 +420,7 @@ func (a *HumanTaskApiService) DeleteTaskFromHumanTaskRecords1(ctx context.Contex
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -497,10 +482,7 @@ func (a *HumanTaskApiService) DeleteTemplateByName(ctx context.Context, name str
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -564,10 +546,7 @@ func (a *HumanTaskApiService) DeleteTemplatesByNameAndVersion(ctx context.Contex
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -652,10 +631,7 @@ func (a *HumanTaskApiService) GetAllTemplates(ctx context.Context, optionals *Hu
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []human.HumanTaskSearch
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -747,10 +723,7 @@ func (a *HumanTaskApiService) GetTask1(ctx context.Context, taskId string, optio
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskEntry
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -832,10 +805,7 @@ func (a *HumanTaskApiService) GetTaskDisplayNames(ctx context.Context, searchTyp
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -919,10 +889,7 @@ func (a *HumanTaskApiService) GetTemplateByNameAndVersion(ctx context.Context, n
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskSearch
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1004,10 +971,7 @@ func (a *HumanTaskApiService) GetTemplateByTaskId(ctx context.Context, humanTask
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskSearch
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1082,10 +1046,7 @@ func (a *HumanTaskApiService) ReassignTask(ctx context.Context, body []human.Hum
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -1147,10 +1108,7 @@ func (a *HumanTaskApiService) ReleaseTask(ctx context.Context, taskId string) (*
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -1233,10 +1191,7 @@ func (a *HumanTaskApiService) SaveTemplate(ctx context.Context, body human.Human
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskSearch
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1329,10 +1284,7 @@ func (a *HumanTaskApiService) SaveTemplates(ctx context.Context, body []human.Hu
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []human.HumanTaskSearch
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1415,10 +1367,7 @@ func (a *HumanTaskApiService) Search(ctx context.Context, body human.HumanTaskSe
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v human.HumanTaskSearchResult
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1501,10 +1450,7 @@ func (a *HumanTaskApiService) SkipTask(ctx context.Context, taskId string, optio
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -1580,10 +1526,7 @@ func (a *HumanTaskApiService) UpdateTaskOutput(ctx context.Context, body map[str
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -1666,10 +1609,7 @@ func (a *HumanTaskApiService) UpdateTaskOutputByRef(ctx context.Context, body ma
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 

--- a/sdk/client/api_human_task.go
+++ b/sdk/client/api_human_task.go
@@ -107,16 +107,6 @@ func (a *HumanTaskApiService) AssignAndClaim(ctx context.Context, taskId string,
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskEntry
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -189,16 +179,6 @@ func (a *HumanTaskApiService) BackPopulateFullTextIndex(ctx context.Context, var
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v map[string]interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -286,16 +266,6 @@ func (a *HumanTaskApiService) ClaimTask(ctx context.Context, taskId string, opti
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskEntry
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -632,16 +602,6 @@ func (a *HumanTaskApiService) GetAllTemplates(ctx context.Context, optionals *Hu
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []human.HumanTaskSearch
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -724,16 +684,6 @@ func (a *HumanTaskApiService) GetTask1(ctx context.Context, taskId string, optio
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskEntry
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -806,16 +756,6 @@ func (a *HumanTaskApiService) GetTaskDisplayNames(ctx context.Context, searchTyp
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -890,16 +830,6 @@ func (a *HumanTaskApiService) GetTemplateByNameAndVersion(ctx context.Context, n
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskSearch
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -972,16 +902,6 @@ func (a *HumanTaskApiService) GetTemplateByTaskId(ctx context.Context, humanTask
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskSearch
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -1192,16 +1112,6 @@ func (a *HumanTaskApiService) SaveTemplate(ctx context.Context, body human.Human
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskSearch
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -1285,16 +1195,6 @@ func (a *HumanTaskApiService) SaveTemplates(ctx context.Context, body []human.Hu
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []human.HumanTaskSearch
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -1368,16 +1268,6 @@ func (a *HumanTaskApiService) Search(ctx context.Context, body human.HumanTaskSe
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v human.HumanTaskSearchResult
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_metadata_resource.go
+++ b/sdk/client/api_metadata_resource.go
@@ -88,10 +88,7 @@ func (a *MetadataResourceApiService) RegisterWorkflowDef(ctx context.Context, ov
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -165,10 +162,7 @@ func (a *MetadataResourceApiService) RegisterWorkflowDefWithTags(ctx context.Con
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -250,10 +244,7 @@ func (a *MetadataResourceApiService) Get(ctx context.Context, name string, local
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.WorkflowDef
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -334,10 +325,7 @@ func (a *MetadataResourceApiService) GetAll(ctx context.Context) ([]model.Workfl
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.WorkflowDef
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -420,10 +408,7 @@ func (a *MetadataResourceApiService) GetTaskDef(ctx context.Context, tasktype st
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.TaskDef
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -504,10 +489,7 @@ func (a *MetadataResourceApiService) GetTaskDefs(ctx context.Context) ([]model.T
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.TaskDef
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -580,10 +562,7 @@ func (a *MetadataResourceApiService) UpdateTaskDef(ctx context.Context, body mod
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -655,10 +634,7 @@ func (a *MetadataResourceApiService) UpdateTaskDefWithTags(ctx context.Context, 
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -721,10 +697,7 @@ func (a *MetadataResourceApiService) RegisterTaskDef(ctx context.Context, body [
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -797,10 +770,7 @@ func (a *MetadataResourceApiService) RegisterTaskDefWithTags(ctx context.Context
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -862,10 +832,7 @@ func (a *MetadataResourceApiService) UnregisterTaskDef(ctx context.Context, task
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -929,10 +896,7 @@ func (a *MetadataResourceApiService) UnregisterWorkflowDef(ctx context.Context, 
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -995,10 +959,7 @@ func (a *MetadataResourceApiService) Update(ctx context.Context, body []model.Wo
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1071,10 +1032,7 @@ func (a *MetadataResourceApiService) UpdateWorkflowDefWithTags(ctx context.Conte
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1149,10 +1107,7 @@ func (a *MetadataResourceApiService) GetTagsForWorkflowDef(ctx context.Context, 
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarReturnValue, newErr
 	}
 
@@ -1226,10 +1181,7 @@ func (a *MetadataResourceApiService) GetTagsForTaskDef(ctx context.Context, task
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarReturnValue, newErr
 	}
 

--- a/sdk/client/api_metadata_resource.go
+++ b/sdk/client/api_metadata_resource.go
@@ -245,16 +245,6 @@ func (a *MetadataResourceApiService) Get(ctx context.Context, name string, local
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.WorkflowDef
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -326,16 +316,6 @@ func (a *MetadataResourceApiService) GetAll(ctx context.Context) ([]model.Workfl
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.WorkflowDef
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -409,16 +389,6 @@ func (a *MetadataResourceApiService) GetTaskDef(ctx context.Context, tasktype st
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.TaskDef
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -490,16 +460,6 @@ func (a *MetadataResourceApiService) GetTaskDefs(ctx context.Context) ([]model.T
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.TaskDef
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 

--- a/sdk/client/api_prompt_resource.go
+++ b/sdk/client/api_prompt_resource.go
@@ -79,10 +79,7 @@ func (a *PromptResourceApiService) DeleteMessageTemplate(ctx context.Context, na
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -147,10 +144,7 @@ func (a *PromptResourceApiService) DeleteTagForPromptTemplate(ctx context.Contex
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -222,10 +216,7 @@ func (a *PromptResourceApiService) GetMessageTemplate(ctx context.Context, name 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 
 		return nil, httpResponse, newErr
 	}
@@ -296,10 +287,7 @@ func (a *PromptResourceApiService) GetMessageTemplates(ctx context.Context) ([]i
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []integration.PromptTemplate
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -381,10 +369,7 @@ func (a *PromptResourceApiService) GetTagsForPromptTemplate(ctx context.Context,
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Tag
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -459,10 +444,7 @@ func (a *PromptResourceApiService) PutTagForPromptTemplate(ctx context.Context, 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -540,10 +522,7 @@ func (a *PromptResourceApiService) SaveMessageTemplate(ctx context.Context, body
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -616,10 +595,7 @@ func (a *PromptResourceApiService) TestMessageTemplate(ctx context.Context, body
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_prompt_resource.go
+++ b/sdk/client/api_prompt_resource.go
@@ -288,16 +288,6 @@ func (a *PromptResourceApiService) GetMessageTemplates(ctx context.Context) ([]i
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []integration.PromptTemplate
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -370,16 +360,6 @@ func (a *PromptResourceApiService) GetTagsForPromptTemplate(ctx context.Context,
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Tag
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -596,16 +576,6 @@ func (a *PromptResourceApiService) TestMessageTemplate(ctx context.Context, body
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_scheduler_resource.go
+++ b/sdk/client/api_scheduler_resource.go
@@ -89,10 +89,7 @@ func (a *SchedulerResourceApiService) DeleteSchedule(ctx context.Context, name s
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -167,10 +164,7 @@ func (a *SchedulerResourceApiService) DeleteTagForSchedule(ctx context.Context, 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -250,10 +244,7 @@ func (a *SchedulerResourceApiService) GetAllSchedules(ctx context.Context, optio
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.WorkflowScheduleModel
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -355,10 +346,7 @@ func (a *SchedulerResourceApiService) GetNextFewSchedules(ctx context.Context, c
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []int64
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -440,10 +428,7 @@ func (a *SchedulerResourceApiService) GetSchedule(ctx context.Context, name stri
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v model.WorkflowSchedule
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -525,10 +510,7 @@ func (a *SchedulerResourceApiService) GetTagsForSchedule(ctx context.Context, na
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Tag
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -608,10 +590,7 @@ func (a *SchedulerResourceApiService) PauseAllSchedules(ctx context.Context) (ma
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v map[string]interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -693,10 +672,7 @@ func (a *SchedulerResourceApiService) PauseSchedule(ctx context.Context, name st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -771,10 +747,7 @@ func (a *SchedulerResourceApiService) PutTagForSchedule(ctx context.Context, bod
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -844,10 +817,7 @@ func (a *SchedulerResourceApiService) RequeueAllExecutionRecords(ctx context.Con
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v map[string]interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -927,10 +897,7 @@ func (a *SchedulerResourceApiService) ResumeAllSchedules(ctx context.Context) (m
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v map[string]interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1012,10 +979,7 @@ func (a *SchedulerResourceApiService) ResumeSchedule(ctx context.Context, name s
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1098,10 +1062,7 @@ func (a *SchedulerResourceApiService) SaveSchedule(ctx context.Context, body mod
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -1212,10 +1173,7 @@ func (a *SchedulerResourceApiService) SearchV2(ctx context.Context, optionals *S
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v model.SearchResultWorkflowSchedule
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_scheduler_resource.go
+++ b/sdk/client/api_scheduler_resource.go
@@ -90,16 +90,6 @@ func (a *SchedulerResourceApiService) DeleteSchedule(ctx context.Context, name s
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -245,16 +235,6 @@ func (a *SchedulerResourceApiService) GetAllSchedules(ctx context.Context, optio
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.WorkflowScheduleModel
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -347,16 +327,6 @@ func (a *SchedulerResourceApiService) GetNextFewSchedules(ctx context.Context, c
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []int64
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -429,16 +399,6 @@ func (a *SchedulerResourceApiService) GetSchedule(ctx context.Context, name stri
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v model.WorkflowSchedule
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -511,16 +471,6 @@ func (a *SchedulerResourceApiService) GetTagsForSchedule(ctx context.Context, na
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Tag
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -591,16 +541,6 @@ func (a *SchedulerResourceApiService) PauseAllSchedules(ctx context.Context) (ma
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v map[string]interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -673,16 +613,6 @@ func (a *SchedulerResourceApiService) PauseSchedule(ctx context.Context, name st
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -818,16 +748,6 @@ func (a *SchedulerResourceApiService) RequeueAllExecutionRecords(ctx context.Con
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v map[string]interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -898,16 +818,6 @@ func (a *SchedulerResourceApiService) ResumeAllSchedules(ctx context.Context) (m
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v map[string]interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -980,16 +890,6 @@ func (a *SchedulerResourceApiService) ResumeSchedule(ctx context.Context, name s
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -1063,16 +963,6 @@ func (a *SchedulerResourceApiService) SaveSchedule(ctx context.Context, body mod
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -1174,16 +1064,6 @@ func (a *SchedulerResourceApiService) SearchV2(ctx context.Context, optionals *S
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v model.SearchResultWorkflowSchedule
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_secret_resource.go
+++ b/sdk/client/api_secret_resource.go
@@ -87,16 +87,6 @@ func (a *SecretResourceApiService) ClearLocalCache(ctx context.Context) (map[str
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v map[string]string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -167,16 +157,6 @@ func (a *SecretResourceApiService) ClearRedisCache(ctx context.Context) (map[str
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v map[string]string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -249,16 +229,6 @@ func (a *SecretResourceApiService) DeleteSecret(ctx context.Context, key string)
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -396,16 +366,6 @@ func (a *SecretResourceApiService) GetSecret(ctx context.Context, key string) (s
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -478,16 +438,6 @@ func (a *SecretResourceApiService) GetTags(ctx context.Context, key string) ([]m
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Tag
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -558,16 +508,6 @@ func (a *SecretResourceApiService) ListAllSecretNames(ctx context.Context) ([]st
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -638,16 +578,6 @@ func (a *SecretResourceApiService) ListSecretsThatUserCanGrantAccessTo(ctx conte
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []string
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -718,16 +648,6 @@ func (a *SecretResourceApiService) ListSecretsWithTagsThatUserCanGrantAccessTo(c
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Secret
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -803,16 +723,6 @@ func (a *SecretResourceApiService) PutSecret(ctx context.Context, body string, k
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -950,16 +860,6 @@ func (a *SecretResourceApiService) SecretExists(ctx context.Context, key string)
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_secret_resource.go
+++ b/sdk/client/api_secret_resource.go
@@ -86,10 +86,7 @@ func (a *SecretResourceApiService) ClearLocalCache(ctx context.Context) (map[str
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v map[string]string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -169,10 +166,7 @@ func (a *SecretResourceApiService) ClearRedisCache(ctx context.Context) (map[str
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v map[string]string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -254,10 +248,7 @@ func (a *SecretResourceApiService) DeleteSecret(ctx context.Context, key string)
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -332,10 +323,7 @@ func (a *SecretResourceApiService) DeleteTagForSecret(ctx context.Context, body 
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -407,10 +395,7 @@ func (a *SecretResourceApiService) GetSecret(ctx context.Context, key string) (s
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -492,10 +477,7 @@ func (a *SecretResourceApiService) GetTags(ctx context.Context, key string) ([]m
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Tag
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -575,10 +557,7 @@ func (a *SecretResourceApiService) ListAllSecretNames(ctx context.Context) ([]st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -658,10 +637,7 @@ func (a *SecretResourceApiService) ListSecretsThatUserCanGrantAccessTo(ctx conte
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []string
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -741,10 +717,7 @@ func (a *SecretResourceApiService) ListSecretsWithTagsThatUserCanGrantAccessTo(c
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Secret
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -829,10 +802,7 @@ func (a *SecretResourceApiService) PutSecret(ctx context.Context, body string, k
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -907,10 +877,7 @@ func (a *SecretResourceApiService) PutTagForSecret(ctx context.Context, body []m
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -982,10 +949,7 @@ func (a *SecretResourceApiService) SecretExists(ctx context.Context, key string)
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_task_resource.go
+++ b/sdk/client/api_task_resource.go
@@ -99,16 +99,6 @@ func (a *TaskResourceApiService) All(ctx context.Context) (map[string]int64, *ht
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v map[string]int64
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -180,16 +170,6 @@ func (a *TaskResourceApiService) AllVerbose(ctx context.Context) (map[string]map
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v map[string]map[string]map[string]int64
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -287,16 +267,6 @@ func (a *TaskResourceApiService) BatchPoll(ctx context.Context, tasktype string,
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.Task
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -368,16 +338,6 @@ func (a *TaskResourceApiService) GetAllPollData(ctx context.Context) ([]model.Po
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.PollData
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -455,16 +415,6 @@ func (a *TaskResourceApiService) GetExternalStorageLocation1(ctx context.Context
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.ExternalStorageLocation
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -538,16 +488,6 @@ func (a *TaskResourceApiService) GetPollData(ctx context.Context, taskType strin
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.PollData
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -621,16 +561,6 @@ func (a *TaskResourceApiService) GetTask(ctx context.Context, taskId string) (mo
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.Task
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -704,16 +634,6 @@ func (a *TaskResourceApiService) GetTaskLogs(ctx context.Context, taskId string)
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.TaskExecLog
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -866,16 +786,6 @@ func (a *TaskResourceApiService) Poll(ctx context.Context, tasktype string, loca
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.Task
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -949,16 +859,6 @@ func (a *TaskResourceApiService) RequeuePendingTask(ctx context.Context, taskTyp
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1060,16 +960,6 @@ func (a *TaskResourceApiService) Search(ctx context.Context, localVarOptionals *
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.SearchResultTaskSummary
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1171,16 +1061,6 @@ func (a *TaskResourceApiService) SearchV2(ctx context.Context, localVarOptionals
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.SearchResultTask
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1261,16 +1141,6 @@ func (a *TaskResourceApiService) Size(ctx context.Context, localVarOptionals *Ta
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v map[string]int32
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1346,16 +1216,6 @@ func (a *TaskResourceApiService) UpdateTask(ctx context.Context, taskResult *mod
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1462,16 +1322,6 @@ func (a *TaskResourceApiService) updateTaskByRefName(ctx context.Context, body m
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 

--- a/sdk/client/api_task_resource.go
+++ b/sdk/client/api_task_resource.go
@@ -98,10 +98,7 @@ func (a *TaskResourceApiService) All(ctx context.Context) (map[string]int64, *ht
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string]int64
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -182,10 +179,7 @@ func (a *TaskResourceApiService) AllVerbose(ctx context.Context) (map[string]map
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string]map[string]map[string]int64
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -292,10 +286,7 @@ func (a *TaskResourceApiService) BatchPoll(ctx context.Context, tasktype string,
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.Task
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -376,10 +367,7 @@ func (a *TaskResourceApiService) GetAllPollData(ctx context.Context) ([]model.Po
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.PollData
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -466,10 +454,7 @@ func (a *TaskResourceApiService) GetExternalStorageLocation1(ctx context.Context
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.ExternalStorageLocation
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -552,10 +537,7 @@ func (a *TaskResourceApiService) GetPollData(ctx context.Context, taskType strin
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.PollData
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -638,10 +620,7 @@ func (a *TaskResourceApiService) GetTask(ctx context.Context, taskId string) (mo
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.Task
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -724,10 +703,7 @@ func (a *TaskResourceApiService) GetTaskLogs(ctx context.Context, taskId string)
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.TaskExecLog
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -802,10 +778,7 @@ func (a *TaskResourceApiService) Log(ctx context.Context, body string, taskId st
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -892,10 +865,7 @@ func (a *TaskResourceApiService) Poll(ctx context.Context, tasktype string, loca
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.Task
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -978,10 +948,7 @@ func (a *TaskResourceApiService) RequeuePendingTask(ctx context.Context, taskTyp
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1092,10 +1059,7 @@ func (a *TaskResourceApiService) Search(ctx context.Context, localVarOptionals *
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.SearchResultTaskSummary
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1206,10 +1170,7 @@ func (a *TaskResourceApiService) SearchV2(ctx context.Context, localVarOptionals
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.SearchResultTask
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1299,10 +1260,7 @@ func (a *TaskResourceApiService) Size(ctx context.Context, localVarOptionals *Ta
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string]int32
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1387,10 +1345,7 @@ func (a *TaskResourceApiService) UpdateTask(ctx context.Context, taskResult *mod
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1506,10 +1461,7 @@ func (a *TaskResourceApiService) updateTaskByRefName(ctx context.Context, body m
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_user_resource.go
+++ b/sdk/client/api_user_resource.go
@@ -98,16 +98,6 @@ func (a *UserResourceApiService) CheckPermissions(ctx context.Context, userId st
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -248,16 +238,6 @@ func (a *UserResourceApiService) GetGrantedPermissions(ctx context.Context, user
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v interface{}
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -406,16 +386,6 @@ func (a *UserResourceApiService) ListUsers(ctx context.Context, optionals *UserR
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []rbac.ConductorUser
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_user_resource.go
+++ b/sdk/client/api_user_resource.go
@@ -97,10 +97,7 @@ func (a *UserResourceApiService) CheckPermissions(ctx context.Context, userId st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -178,10 +175,7 @@ func (a *UserResourceApiService) DeleteUser(ctx context.Context, id string) (*ht
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -253,10 +247,7 @@ func (a *UserResourceApiService) GetGrantedPermissions(ctx context.Context, user
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v interface{}
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -338,10 +329,7 @@ func (a *UserResourceApiService) GetUser(ctx context.Context, id string) (*rbac.
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return nil, httpResponse, newErr
 	}
 
@@ -417,10 +405,7 @@ func (a *UserResourceApiService) ListUsers(ctx context.Context, optionals *UserR
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []rbac.ConductorUser
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -505,10 +490,7 @@ func (a *UserResourceApiService) UpsertUser(ctx context.Context, body rbac.Upser
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return nil, httpResponse, newErr
 	}
 

--- a/sdk/client/api_webhooks_config_resource.go
+++ b/sdk/client/api_webhooks_config_resource.go
@@ -90,10 +90,7 @@ func (a *WebhooksConfigResourceApiService) CreateWebhook(ctx context.Context, bo
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v model.WebhookConfig
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -166,10 +163,7 @@ func (a *WebhooksConfigResourceApiService) DeleteTagForWebhook(ctx context.Conte
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -231,10 +225,7 @@ func (a *WebhooksConfigResourceApiService) DeleteWebhook(ctx context.Context, id
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -304,10 +295,7 @@ func (a *WebhooksConfigResourceApiService) GetAllWebhook(ctx context.Context) ([
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.WebhookConfig
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -389,10 +377,7 @@ func (a *WebhooksConfigResourceApiService) GetTagsForWebhook(ctx context.Context
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v []model.Tag
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -474,10 +459,7 @@ func (a *WebhooksConfigResourceApiService) GetWebhook(ctx context.Context, id st
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v model.WebhookConfig
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
@@ -552,10 +534,7 @@ func (a *WebhooksConfigResourceApiService) PutTagForWebhook(ctx context.Context,
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		return httpResponse, newErr
 	}
 
@@ -630,10 +609,7 @@ func (a *WebhooksConfigResourceApiService) UpdateWebhook(ctx context.Context, bo
 	}
 
 	if httpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  responseBody,
-			error: httpResponse.Status,
-		}
+		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
 		if httpResponse.StatusCode == 200 {
 			var v model.WebhookConfig
 			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_webhooks_config_resource.go
+++ b/sdk/client/api_webhooks_config_resource.go
@@ -91,16 +91,6 @@ func (a *WebhooksConfigResourceApiService) CreateWebhook(ctx context.Context, bo
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v model.WebhookConfig
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -296,16 +286,6 @@ func (a *WebhooksConfigResourceApiService) GetAllWebhook(ctx context.Context) ([
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.WebhookConfig
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -378,16 +358,6 @@ func (a *WebhooksConfigResourceApiService) GetTagsForWebhook(ctx context.Context
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v []model.Tag
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -460,16 +430,6 @@ func (a *WebhooksConfigResourceApiService) GetWebhook(ctx context.Context, id st
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v model.WebhookConfig
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 
@@ -610,16 +570,6 @@ func (a *WebhooksConfigResourceApiService) UpdateWebhook(ctx context.Context, bo
 
 	if httpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
-		if httpResponse.StatusCode == 200 {
-			var v model.WebhookConfig
-			err = a.decode(&v, responseBody, httpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return returnValue, httpResponse, newErr
-			}
-			newErr.model = v
-			return returnValue, httpResponse, newErr
-		}
 		return returnValue, httpResponse, newErr
 	}
 

--- a/sdk/client/api_workflow_bulk_resource.go
+++ b/sdk/client/api_workflow_bulk_resource.go
@@ -95,10 +95,7 @@ func (a *WorkflowBulkResourceApiService) PauseWorkflow1(ctx context.Context, bod
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.BulkResponse
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -194,10 +191,7 @@ func (a *WorkflowBulkResourceApiService) Restart1(ctx context.Context, body []st
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.BulkResponse
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -285,10 +279,7 @@ func (a *WorkflowBulkResourceApiService) ResumeWorkflow1(ctx context.Context, bo
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.BulkResponse
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -375,10 +366,7 @@ func (a *WorkflowBulkResourceApiService) Retry1(ctx context.Context, body []stri
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.BulkResponse
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -476,10 +464,7 @@ func (a *WorkflowBulkResourceApiService) Terminate(ctx context.Context, body []s
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.BulkResponse
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/sdk/client/api_workflow_resource.go
+++ b/sdk/client/api_workflow_resource.go
@@ -84,10 +84,7 @@ func (a *WorkflowResourceApiService) Decide(ctx context.Context, workflowId stri
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -160,10 +157,7 @@ func (a *WorkflowResourceApiService) Delete(ctx context.Context, workflowId stri
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -245,10 +239,7 @@ func (a *WorkflowResourceApiService) GetExecutionStatus(ctx context.Context, wor
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.Workflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -326,10 +317,7 @@ func (a *WorkflowResourceApiService) GetWorkflowState(ctx context.Context, workf
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.Workflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -416,10 +404,7 @@ func (a *WorkflowResourceApiService) GetExternalStorageLocation(ctx context.Cont
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.ExternalStorageLocation
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -521,10 +506,7 @@ func (a *WorkflowResourceApiService) GetRunningWorkflow(ctx context.Context, nam
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -619,10 +601,7 @@ func (a *WorkflowResourceApiService) GetWorkflows(ctx context.Context, body []st
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string][]model.Workflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -704,10 +683,7 @@ func (a *WorkflowResourceApiService) GetWorkflowsBatch(ctx context.Context, body
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v map[string][]model.Workflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -809,10 +785,7 @@ func (a *WorkflowResourceApiService) GetWorkflows1(ctx context.Context, name str
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v []model.Workflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -884,10 +857,7 @@ func (a *WorkflowResourceApiService) PauseWorkflow(ctx context.Context, workflow
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -963,10 +933,7 @@ func (a *WorkflowResourceApiService) Rerun(ctx context.Context, body model.Rerun
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1038,10 +1005,7 @@ func (a *WorkflowResourceApiService) ResetWorkflow(ctx context.Context, workflow
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1114,10 +1078,7 @@ func (a *WorkflowResourceApiService) Restart(ctx context.Context, workflowId str
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1179,10 +1140,7 @@ func (a *WorkflowResourceApiService) ResumeWorkflow(ctx context.Context, workflo
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1255,10 +1213,7 @@ func (a *WorkflowResourceApiService) Retry(ctx context.Context, workflowId strin
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1359,10 +1314,7 @@ func (a *WorkflowResourceApiService) Search(ctx context.Context, localVarOptiona
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.SearchResultWorkflowSummary
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1473,10 +1425,7 @@ func (a *WorkflowResourceApiService) SearchV2(ctx context.Context, localVarOptio
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.SearchResultWorkflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1587,10 +1536,7 @@ func (a *WorkflowResourceApiService) SearchWorkflowsByTasks(ctx context.Context,
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.SearchResultWorkflowSummary
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1701,10 +1647,7 @@ func (a *WorkflowResourceApiService) SearchWorkflowsByTasksV2(ctx context.Contex
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.SearchResultWorkflow
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -1780,10 +1723,7 @@ func (a *WorkflowResourceApiService) SkipTaskFromWorkflow(ctx context.Context, w
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 
@@ -1878,10 +1818,7 @@ func (a *WorkflowResourceApiService) StartWorkflow(ctx context.Context, body map
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -2052,10 +1989,7 @@ func (a *WorkflowResourceApiService) StartWorkflowWithRequest(ctx context.Contex
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v string
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -2143,10 +2077,7 @@ func (a *WorkflowResourceApiService) Terminate(ctx context.Context, workflowId s
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		return localVarHttpResponse, newErr
 	}
 

--- a/sdk/client/api_workflow_resource.go
+++ b/sdk/client/api_workflow_resource.go
@@ -240,16 +240,6 @@ func (a *WorkflowResourceApiService) GetExecutionStatus(ctx context.Context, wor
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.Workflow
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -318,16 +308,6 @@ func (a *WorkflowResourceApiService) GetWorkflowState(ctx context.Context, workf
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.Workflow
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -405,16 +385,6 @@ func (a *WorkflowResourceApiService) GetExternalStorageLocation(ctx context.Cont
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.ExternalStorageLocation
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -507,16 +477,6 @@ func (a *WorkflowResourceApiService) GetRunningWorkflow(ctx context.Context, nam
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -602,16 +562,6 @@ func (a *WorkflowResourceApiService) GetWorkflows(ctx context.Context, body []st
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v map[string][]model.Workflow
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -684,16 +634,6 @@ func (a *WorkflowResourceApiService) GetWorkflowsBatch(ctx context.Context, body
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v map[string][]model.Workflow
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -786,16 +726,6 @@ func (a *WorkflowResourceApiService) GetWorkflows1(ctx context.Context, name str
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []model.Workflow
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -934,16 +864,6 @@ func (a *WorkflowResourceApiService) Rerun(ctx context.Context, body model.Rerun
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1315,16 +1235,6 @@ func (a *WorkflowResourceApiService) Search(ctx context.Context, localVarOptiona
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.SearchResultWorkflowSummary
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1426,16 +1336,6 @@ func (a *WorkflowResourceApiService) SearchV2(ctx context.Context, localVarOptio
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.SearchResultWorkflow
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1537,16 +1437,6 @@ func (a *WorkflowResourceApiService) SearchWorkflowsByTasks(ctx context.Context,
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.SearchResultWorkflowSummary
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1819,16 +1709,6 @@ func (a *WorkflowResourceApiService) StartWorkflow(ctx context.Context, body map
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 
@@ -1990,16 +1870,6 @@ func (a *WorkflowResourceApiService) StartWorkflowWithRequest(ctx context.Contex
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v string
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 

--- a/sdk/client/generic_swagger_error.go
+++ b/sdk/client/generic_swagger_error.go
@@ -13,9 +13,10 @@ import "fmt"
 
 // GenericSwaggerError Provides access to the body, error and model on returned errors.
 type GenericSwaggerError struct {
-	body  []byte
-	error string
-	model interface{}
+	body       []byte
+	error      string
+	model      interface{}
+	statusCode int
 }
 
 // Error returns non-empty string if there was an error.
@@ -31,4 +32,17 @@ func (e GenericSwaggerError) Body() []byte {
 // Model returns the unpacked model of the error
 func (e GenericSwaggerError) Model() interface{} {
 	return e.model
+}
+
+func (e GenericSwaggerError) StatusCode() int {
+	return e.statusCode
+}
+
+func NewGenericSwaggerError(body []byte, errorMsg string, model interface{}, statusCode int) GenericSwaggerError {
+	return GenericSwaggerError{
+		body:       body,
+		error:      errorMsg,
+		model:      model,
+		statusCode: statusCode,
+	}
 }

--- a/sdk/client/health_check_resource.go
+++ b/sdk/client/health_check_resource.go
@@ -29,7 +29,8 @@ type HealthCheckResourceApiService struct {
 
 /*
 HealthCheckResourceApiService
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+  - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+
 @return http_model.HealthCheckStatus
 */
 func (a *HealthCheckResourceApiService) DoCheck(ctx context.Context) (model.HealthCheckStatus, *http.Response, error) {
@@ -90,10 +91,7 @@ func (a *HealthCheckResourceApiService) DoCheck(ctx context.Context) (model.Heal
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericSwaggerError{
-			body:  localVarBody,
-			error: string(localVarBody),
-		}
+		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
 		if localVarHttpResponse.StatusCode == 200 {
 			var v model.HealthCheckStatus
 			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/sdk/client/health_check_resource.go
+++ b/sdk/client/health_check_resource.go
@@ -92,16 +92,6 @@ func (a *HealthCheckResourceApiService) DoCheck(ctx context.Context) (model.Heal
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
-		if localVarHttpResponse.StatusCode == 200 {
-			var v model.HealthCheckStatus
-			err = a.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}
 

--- a/sdk/workflow/executor/executor.go
+++ b/sdk/workflow/executor/executor.go
@@ -217,6 +217,7 @@ func (e *WorkflowExecutor) getWorkflow(retry int, workflowId string, includeTask
 		return nil, err
 	}
 	if err != nil {
+
 		if retry < 0 {
 			return nil, err
 		} else {
@@ -313,7 +314,7 @@ func (e *WorkflowExecutor) Pause(workflowId string) error {
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 // Resume the execution of a workflow that is paused.  If the workflow is not paused, this method has no effect
@@ -322,7 +323,7 @@ func (e *WorkflowExecutor) Resume(workflowId string) error {
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 // Terminate a running workflow.  Reason must be provided that is captured as the termination resaon for the workflow
@@ -338,7 +339,7 @@ func (e *WorkflowExecutor) Terminate(workflowId string, reason string) error {
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 func (e *WorkflowExecutor) TerminateWithFailure(workflowId string, reason string, triggerFailureWorkflow bool) error {
@@ -353,7 +354,7 @@ func (e *WorkflowExecutor) TerminateWithFailure(workflowId string, reason string
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 // Restart a workflow execution from the beginning with the same input.
@@ -369,7 +370,7 @@ func (e *WorkflowExecutor) Restart(workflowId string, useLatestDefinition bool) 
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 // Retry a failed workflow from the last task that failed.  When called the task in the failed state is scheduled again
@@ -384,9 +385,9 @@ func (e *WorkflowExecutor) Retry(workflowId string, resumeSubworkflowTasks bool)
 		},
 	)
 	if err != nil {
-		return nil
+		return err
 	}
-	return err
+	return nil
 }
 
 // ReRun a completed workflow from a specific task (ReRunFromTaskId) and optionally change the input

--- a/test/integration_tests/executor_test.go
+++ b/test/integration_tests/executor_test.go
@@ -1,0 +1,25 @@
+package integration_tests
+
+import (
+	"testing"
+
+	"github.com/conductor-sdk/conductor-go/sdk/client"
+	"github.com/conductor-sdk/conductor-go/test/testdata"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryNotFound(t *testing.T) {
+	executor := testdata.WorkflowExecutor
+	// Workflow id is hardcoded on purpose. It should not be found.
+	err := executor.Retry("2b3ea839-9aeb-11ef-9ac5-ce590b39fb93", true)
+	assert.Error(t, err, "Retry is expected to return an error")
+
+	if swaggerErr, ok := err.(client.GenericSwaggerError); ok {
+		// hmm... this should be a 404 or 400, but it's a 500 right now.
+		assert.Error(t, err, "GetWorkflow was expected to return a 500 error")
+		assert.Equal(t, 500, swaggerErr.StatusCode())
+	} else {
+		assert.Fail(t, "err is not of type GenericSwaggerError ")
+	}
+
+}


### PR DESCRIPTION
- Added `statusCode int` field to `GenericSwaggerError` to expose http status code.
- Refactored `GenericSwaggerError` creation to constructor function. i.e.: Replaced all occurrences of 

```golang
newErr := GenericSwaggerError{
	body:  localVarBody,
	error: string(localVarBody),
}

// with

newErr := NewGenericSwaggerError(localVarBody, string(localVarBody), nil, localVarHttpResponse.StatusCode)
```

And

```golang

newErr := GenericSwaggerError{
	body:  responseBody,
	error: httpResponse.Status,
}

// with

newErr := NewGenericSwaggerError(responseBody, httpResponse.Status, nil, httpResponse.StatusCode)
```

