### PR TITLE
Task Runner graceful shutdown

### DIFF
--- a/sdk/worker/task_runner.go
+++ b/sdk/worker/task_runner.go
@@ -206,10 +206,17 @@ func (c *TaskRunner) Resume(taskName string) {
 // a signal will be sent to the WaitGroup to indicate that this worker has completed its work.
 // When used in conjunction with TaskRunner.WaitWorkers() it allows a graceful shutdown.
 func (c *TaskRunner) Shutdown(taskName string) {
-	c.pausedWorkersMutex.Lock()
-	defer c.pausedWorkersMutex.Unlock()
+	c.batchSizeByTaskNameMutex.Lock()
 	delete(c.batchSizeByTaskName, taskName)
+	c.batchSizeByTaskNameMutex.Unlock()
+
+	c.pausedWorkersMutex.Lock()
 	delete(c.pausedWorkers, taskName)
+	c.pausedWorkersMutex.Unlock()
+
+	c.pollIntervalByTaskNameMutex.Lock()
+	delete(c.pollIntervalByTaskName, taskName)
+	c.pollIntervalByTaskNameMutex.Unlock()
 }
 
 func (c *TaskRunner) isPaused(taskName string) bool {

--- a/sdk/worker/task_runner.go
+++ b/sdk/worker/task_runner.go
@@ -202,6 +202,16 @@ func (c *TaskRunner) Resume(taskName string) {
 	c.pausedWorkers[taskName] = false
 }
 
+// Shutdown the TaskRunner will stop polling for tasks and once all running workers are done,
+// a signal will be sent to the WaitGroup to indicate that this worker has completed its work.
+// When used in conjunction with TaskRunner.WaitWorkers() it allows a graceful shutdown.
+func (c *TaskRunner) Shutdown(taskName string) {
+	c.pausedWorkersMutex.Lock()
+	defer c.pausedWorkersMutex.Unlock()
+	delete(c.batchSizeByTaskName, taskName)
+	delete(c.pausedWorkers, taskName)
+}
+
 func (c *TaskRunner) isPaused(taskName string) bool {
 	c.pausedWorkersMutex.RLock()
 	defer c.pausedWorkersMutex.RUnlock()
@@ -209,7 +219,7 @@ func (c *TaskRunner) isPaused(taskName string) bool {
 }
 
 // WaitWorkers uses an internal waitgroup to block the calling thread until all workers started by this TaskRunner have
-// been stopped.
+// been shut down.
 func (c *TaskRunner) WaitWorkers() {
 	c.workerWaitGroup.Wait()
 }
@@ -469,6 +479,7 @@ func (c *TaskRunner) increaseRunningWorkers(taskName string) error {
 	c.runningWorkersByTaskNameMutex.Lock()
 	defer c.runningWorkersByTaskNameMutex.Unlock()
 	c.runningWorkersByTaskName[taskName] += 1
+	c.workerWaitGroup.Add(1)
 	log.Trace("Increased running workers for task: ", taskName)
 	return nil
 }
@@ -477,6 +488,7 @@ func (c *TaskRunner) runningWorkerDone(taskName string) error {
 	c.runningWorkersByTaskNameMutex.Lock()
 	defer c.runningWorkersByTaskNameMutex.Unlock()
 	c.runningWorkersByTaskName[taskName] -= 1
+	c.workerWaitGroup.Done()
 	log.Trace("Running worker done for task: ", taskName)
 	return nil
 }


### PR DESCRIPTION
Calling `taskRunner.Shutdown(taskName)` enables a graceful shutdown of a Task Runner when used alongside `taskRunner.WaitWorkers()`.  

When `taskRunner.Shutdown(taskName)` is invoked, the Task Runner stops polling for the task. Once all active workers in this Task Runner complete, the `WaitGroup` counter reaches zero, allowing `WaitWorkers()` to proceed without blocking execution.

**NOTES**
- Closes #97 - A very old issue which was overlooked because dynamically adding/removing is not that common.
- Apart from the unit test that checks that `Shutdown(taskName)` unblocks the call to `WaitWorkers()` I tested running https://github.com/jmigueprieto/go_dynamic_workers/blob/main/worker.go adding and shutting down workers dynamically.

