### PR TITLE
batch poll timeout configuration

### DIFF
--- a/sdk/worker/task_runner.go
+++ b/sdk/worker/task_runner.go
@@ -61,6 +61,10 @@ type TaskRunner struct {
 
 	pausedWorkersMutex sync.RWMutex
 	pausedWorkers      map[string]bool
+
+	pollTimeoutMutex      sync.RWMutex
+	pollTimeout           time.Duration
+	pollTimeoutByTaskName map[string]time.Duration
 }
 
 // NewTaskRunner returns a new TaskRunner which authenticates via HTTP using the provided settings.
@@ -85,6 +89,8 @@ func NewTaskRunnerWithApiClient(
 		runningWorkersByTaskName: make(map[string]int),
 		pollIntervalByTaskName:   make(map[string]time.Duration),
 		pausedWorkers:            make(map[string]bool),
+		pollTimeoutByTaskName:    make(map[string]time.Duration),
+		pollTimeout:              -1 * time.Millisecond, //If negative, the server will use its default.
 	}
 }
 
@@ -223,6 +229,10 @@ func (c *TaskRunner) Shutdown(taskName string) {
 	c.pollIntervalByTaskNameMutex.Lock()
 	delete(c.pollIntervalByTaskName, taskName)
 	c.pollIntervalByTaskNameMutex.Unlock()
+
+	c.pollTimeoutMutex.Lock()
+	delete(c.pollTimeoutByTaskName, taskName)
+	c.pollTimeoutMutex.Unlock()
 }
 
 func (c *TaskRunner) isPaused(taskName string) bool {
@@ -326,7 +336,7 @@ func (c *TaskRunner) executeAndUpdateTask(taskName string, task model.Task, exec
 }
 
 func (c *TaskRunner) batchPoll(taskName string, count int, domain string) ([]model.Task, error) {
-	timeout, err := c.GetPollIntervalForTask(taskName)
+	timeout, err := c.GetPollTimeoutForTask(taskName)
 	if err != nil {
 		return nil, err
 	}
@@ -334,21 +344,23 @@ func (c *TaskRunner) batchPoll(taskName string, count int, domain string) ([]mod
 	if domain != "" {
 		domainOptional = optional.NewString(domain)
 	}
-	log.Debug(
-		"Polling for task: ", taskName,
-		", in batches of size: ", count,
-	)
+	log.Debug("Polling for task: ", taskName, ", in batches of size: ", count, ", with poll timeout: ", timeout)
 	metrics.IncrementTaskPoll(taskName)
 	startTime := time.Now()
+	opts := &client.TaskResourceApiBatchPollOpts{
+		Domain:   domainOptional,
+		Workerid: optional.NewString(hostname),
+		Count:    optional.NewInt32(int32(count)),
+	}
+
+	if timeout >= 0 {
+		opts.Timeout = optional.NewInt32(int32(timeout.Milliseconds()))
+	}
+
 	tasks, response, err := c.conductorTaskResourceClient.BatchPoll(
 		context.Background(),
 		taskName,
-		&client.TaskResourceApiBatchPollOpts{
-			Domain:   domainOptional,
-			Workerid: optional.NewString(hostname),
-			Count:    optional.NewInt32(int32(count)),
-			Timeout:  optional.NewInt32(int32(timeout.Milliseconds())),
-		},
+		opts,
 	)
 	spentTime := time.Since(startTime)
 	metrics.RecordTaskPollTime(
@@ -566,4 +578,44 @@ func pauseOnGenericError(taskName string, domain string, err error) {
 func pauseOnNoAvailableWorkerError(taskName string, domain string) {
 	log.Trace(fmt.Errorf("no worker available for the task %s, domain %s", taskName, domain))
 	time.Sleep(sleepForOnNoAvailableWorker)
+}
+
+// SetPollTimeout sets the default poll timeout for all tasks. If not explicitly set,
+// it defaults to a negative value, indicating that the server's default should be used.
+func (c *TaskRunner) SetPollTimeout(pollTimeout time.Duration) error {
+	c.pollTimeoutMutex.Lock()
+	defer c.pollTimeoutMutex.Unlock()
+	c.pollTimeout = pollTimeout
+	return nil
+}
+
+// GetPollTimeout gets the default poll timeout for all tasks. The value may be negative.
+// In such cases, pollTimeout parameter is not sent, indicating that the server's default should be used.
+func (c *TaskRunner) GetPollTimeout() time.Duration {
+	c.pollTimeoutMutex.Lock()
+	defer c.pollTimeoutMutex.Unlock()
+	return c.pollTimeout
+}
+
+// GetPollTimeoutForTask retrieves the poll timeout for all tasks running with the provided taskName.
+// If there isn't a specific poll timeout for the task it uses the default timeout TaskRunner.pollTimeout.
+func (c *TaskRunner) GetPollTimeoutForTask(taskName string) (time.Duration, error) {
+	c.pollTimeoutMutex.Lock()
+	defer c.pollTimeoutMutex.Unlock()
+
+	pollTimeout, ok := c.pollTimeoutByTaskName[taskName]
+	if !ok {
+		return c.pollTimeout, nil
+	}
+
+	return pollTimeout, nil
+}
+
+// SetPollTimeoutForTask sets the pollInterval for all workers running the task with the provided taskName.
+func (c *TaskRunner) SetPollTimeoutForTask(taskName string, pollTimeout time.Duration) error {
+	c.pollTimeoutMutex.Lock()
+	defer c.pollTimeoutMutex.Unlock()
+	c.pollTimeoutByTaskName[taskName] = pollTimeout
+	log.Info("Updated poll timeout for task: ", taskName, ", to: ", pollTimeout.Milliseconds(), "ms")
+	return nil
 }

--- a/sdk/worker/task_runner.go
+++ b/sdk/worker/task_runner.go
@@ -531,7 +531,7 @@ func (c *TaskRunner) SetPollIntervalForTask(taskName string, pollInterval time.D
 	c.pollIntervalByTaskNameMutex.Lock()
 	defer c.pollIntervalByTaskNameMutex.Unlock()
 	c.pollIntervalByTaskName[taskName] = pollInterval
-	log.Info("Updated poll interval for task: ", taskName, ", to: ", pollInterval.Milliseconds(), "ms")
+	log.Info("Updated poll interval for task: ", taskName, " to: ", pollInterval.Milliseconds(), "ms")
 	return nil
 }
 
@@ -586,6 +586,7 @@ func (c *TaskRunner) SetPollTimeout(pollTimeout time.Duration) error {
 	c.pollTimeoutMutex.Lock()
 	defer c.pollTimeoutMutex.Unlock()
 	c.pollTimeout = pollTimeout
+	log.Info("Updated poll timeout to: ", pollTimeout.Milliseconds(), "ms")
 	return nil
 }
 
@@ -616,6 +617,6 @@ func (c *TaskRunner) SetPollTimeoutForTask(taskName string, pollTimeout time.Dur
 	c.pollTimeoutMutex.Lock()
 	defer c.pollTimeoutMutex.Unlock()
 	c.pollTimeoutByTaskName[taskName] = pollTimeout
-	log.Info("Updated poll timeout for task: ", taskName, ", to: ", pollTimeout.Milliseconds(), "ms")
+	log.Info("Updated poll timeout for task: ", taskName, " to: ", pollTimeout.Milliseconds(), "ms")
 	return nil
 }


### PR DESCRIPTION
## Changes in this PR

- Using polling interval as poll timeout is not right. Added poll timeout config options to task runner.