### PR TITLE
feat: added golangci-lint ‘new only’ check to CI pipeline

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,38 @@
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci.yml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.3
+          only-new-issues: true
+          args: --timeout 10m --issues-exit-code=1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,47 @@
+version: "2"
+
+linters:
+  enable:
+    # Bugs and errors
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - revive
+    # Performance
+    - prealloc
+    # Complexity
+    - gocyclo
+    - gocognit
+    # Security
+    - gosec
+
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    govet:
+      enable:
+        - shadow
+    gocyclo:
+      min-complexity: 15
+
+  exclusions:
+    paths:
+      - ".*_test.go"
+      - ".*_mock.go"
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+run:
+  timeout: 10m
+  issues-exit-code: 1
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0


### PR DESCRIPTION
## Summary
Added golangci-lint to CI pipeline with `only-new-issues: true` to catch new linting issues in PRs without breaking builds on existing code.