### PR TITLE
FIX: `subWorkflowParam.workflowDefinition` unmarshalling issue

### DIFF
--- a/sdk/model/sub_workflow_params.go
+++ b/sdk/model/sub_workflow_params.go
@@ -35,8 +35,8 @@ func NewWorkflowDefinitionExpression(expr string) *WorkflowDefinitionParam {
 	}
 }
 
-// NewWorkflowDefinitionObject creates a WorkflowDefinitionParam from a WorkflowDef object.
-func NewWorkflowDefinitionObject(def *WorkflowDef) *WorkflowDefinitionParam {
+// NewWorkflowDefinitionParam creates a WorkflowDefinitionParam from a WorkflowDef object.
+func NewWorkflowDefinitionParam(def *WorkflowDef) *WorkflowDefinitionParam {
 	return &WorkflowDefinitionParam{
 		definition: def,
 	}

--- a/sdk/model/sub_workflow_params_test.go
+++ b/sdk/model/sub_workflow_params_test.go
@@ -77,7 +77,7 @@ func TestWorkflowDefinitionParam_MarshalJSON_WorkflowDef(t *testing.T) {
 		Version:     1,
 		Description: "Test workflow",
 	}
-	param := NewWorkflowDefinitionObject(workflowDef)
+	param := NewWorkflowDefinitionParam(workflowDef)
 
 	data, err := json.Marshal(param)
 
@@ -107,9 +107,9 @@ func TestWorkflowDefinitionParam_Constructors(t *testing.T) {
 		assert.Equal(t, "${workflow.input.test}", expr)
 	})
 
-	t.Run("NewWorkflowDefinitionObject", func(t *testing.T) {
+	t.Run("NewWorkflowDefinitionParam", func(t *testing.T) {
 		workflowDef := &WorkflowDef{Name: "test"}
-		param := NewWorkflowDefinitionObject(workflowDef)
+		param := NewWorkflowDefinitionParam(workflowDef)
 
 		assert.False(t, param.IsExpression())
 		assert.True(t, param.IsDefinition())
@@ -223,7 +223,7 @@ func TestSubWorkflowParams_MarshalJSON_RoundTrip(t *testing.T) {
 		params := SubWorkflowParams{
 			Name:    "test_workflow",
 			Version: 1,
-			WorkflowDefinition: NewWorkflowDefinitionObject(&WorkflowDef{
+			WorkflowDefinition: NewWorkflowDefinitionParam(&WorkflowDef{
 				Name:        "inline",
 				Version:     2,
 				Description: "Test",

--- a/sdk/workflow/sub_workflow.go
+++ b/sdk/workflow/sub_workflow.go
@@ -60,7 +60,7 @@ func (task *SubWorkflowTask) toWorkflowTask() []model.WorkflowTask {
 		workflowTasks[0].SubWorkflowParam = &model.SubWorkflowParams{
 			Name:               task.workflow.name,
 			TaskToDomain:       task.taskToDomainMap,
-			WorkflowDefinition: model.NewWorkflowDefinitionObject(task.workflow.ToWorkflowDef()),
+			WorkflowDefinition: model.NewWorkflowDefinitionParam(task.workflow.ToWorkflowDef()),
 		}
 	} else {
 		workflowTasks[0].SubWorkflowParam = &model.SubWorkflowParams{


### PR DESCRIPTION
`subWorkflowParam.workflowDefinition` might be a string, an expression like `"${workflow.input.wf_def}"`

This causes JSON unmarshalling issues because it's expecting a `WorkflowDef`. E.g.:

```json
{
  "name": "NewWorkflow_eqin9",
  "description": ".",
  "version": 1,
  "tasks": [
    {
      "name": "sub_workflow",
      "taskReferenceName": "sub_workflow_ref",
      "inputParameters": {},
      "type": "SUB_WORKFLOW",
      "startDelay": 0,
      "subWorkflowParam": {
        "name": "some_workflow",
        "version": 1,
        "workflowDefinition": "${workflow.input.wf_def}"
      }    
   }
  ],
  "schemaVersion": 2,
  "restartable": true,
  "workflowStatusListenerEnabled": false,
  "timeoutPolicy": "ALERT_ONLY",
  "timeoutSeconds": 0]
}
```
