### PR TITLE
Add Metadata field to WorkflowDef struct

### DIFF
--- a/sdk/model/workflow_def.go
+++ b/sdk/model/workflow_def.go
@@ -35,6 +35,7 @@ type WorkflowDef struct {
 	TimeoutPolicy                 string                 `json:"timeoutPolicy,omitempty"`
 	TimeoutSeconds                int64                  `json:"timeoutSeconds"`
 	Variables                     map[string]interface{} `json:"variables,omitempty"`
+	Metadata                      map[string]interface{} `json:"metadata,omitempty"`
 	InputTemplate                 map[string]interface{} `json:"inputTemplate,omitempty"`
 	Tags                          []TagObject            `json:"tags,omitempty"`
 	OverwriteTags                 bool                   `json:"overwriteTags"`


### PR DESCRIPTION
Add the 'metadata' field to WorkflowDef to support custom metadata that Conductor server returns in workflow definitions.

The Conductor API includes a metadata field in workflow definitions for storing UI-specific information, but the Go SDK's WorkflowDef struct was missing this field, causing it to be ignored during JSON unmarshaling.