### PR TITLE
fix: bump protobuf to v1.33.0 (CVE fix)

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -23,5 +23,5 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,6 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -470,8 +470,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
-google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/test/backward_compatibility/currentCodeVersion/go.mod
+++ b/test/backward_compatibility/currentCodeVersion/go.mod
@@ -19,5 +19,5 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/test/backward_compatibility/releasedVersion/go.mod
+++ b/test/backward_compatibility/releasedVersion/go.mod
@@ -19,5 +19,5 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )


### PR DESCRIPTION
## Summary

- Bumps `google.golang.org/protobuf` from v1.26.0 to v1.33.0 in all four `go.mod` files
- Fixes infinite loop vulnerability in JSON unmarshaling (GO-2024-2611 / GHSA-8r3f-844c-mc37)

## Changes

Updated protobuf dependency in:
- `go.mod` (root module, go 1.23)
- `examples/go.mod` (go 1.23)
- `test/backward_compatibility/releasedVersion/go.mod` (go 1.17)
- `test/backward_compatibility/currentCodeVersion/go.mod` (go 1.17)

## References

- Fixes #247
- https://pkg.go.dev/vuln/GO-2024-2611
- https://github.com/advisories/GHSA-8r3f-844c-mc37

## Test plan

- [ ] CI passes with updated dependency
- [ ] Run `go mod tidy` in each module to verify go.sum consistency
- [ ] Verify no breaking changes from protobuf version bump

## Note

The `go.sum` was updated manually since `go mod tidy` was not available in the build environment. If CI fails on checksum verification, running `go mod tidy` in the root module should fix it.