### PR TITLE
fix: Register(overwrite=true) uses PUT /metadata/workflow

### DIFF
--- a/sdk/workflow/executor/executor_with_context.go
+++ b/sdk/workflow/executor/executor_with_context.go
@@ -20,6 +20,13 @@ func (e *WorkflowExecutor) RegisterWorkflowWithContext(ctx context.Context, over
 		return err
 	}
 
+	if overwrite {
+		// POST /metadata/workflow does not honor the overwrite param on the OSS
+		// server — it returns HTTP 500 if the workflow already exists.
+		// Use PUT /metadata/workflow instead when overwrite=true.
+		_, err := e.metadataClient.Update(ctx, []model.WorkflowDef{*workflow})
+		return err
+	}
 	_, err := e.metadataClient.RegisterWorkflowDef(ctx, overwrite, *workflow)
 	return err
 }


### PR DESCRIPTION
## Summary
- `Register(overwrite=true)` was calling `POST /metadata/workflow?overwrite=true`
- The Conductor OSS server ignores the `overwrite` param on POST and returns HTTP 500 if the workflow already exists
- Fix: branch on the `overwrite` flag in `RegisterWorkflowWithContext` — use `PUT /metadata/workflow` (via existing `metadataClient.Update`) when `overwrite=true`

## Test plan
- [ ] Run `hello_world` example twice in a row against a local OSS server — second run should succeed instead of returning HTTP 500
- [ ] Existing unit tests pass

Fixes #252
🤖 Generated with [Claude Code](https://claude.com/claude-code)